### PR TITLE
Add EF Core configuration for evaluation forms

### DIFF
--- a/src/Infrastructure/Configurations/EvaluationFormConfiguration.cs
+++ b/src/Infrastructure/Configurations/EvaluationFormConfiguration.cs
@@ -1,0 +1,110 @@
+using CascVel.Module.Evaluations.Management.Domain.Entities.Forms;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CascVel.Module.Evaluations.Management.Infrastructure.Configurations;
+
+internal sealed class EvaluationFormConfiguration : IEntityTypeConfiguration<EvaluationForm>
+{
+    public void Configure(EntityTypeBuilder<EvaluationForm> builder)
+    {
+        builder.ToTable("forms");
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).HasColumnName("id").ValueGeneratedOnAdd();
+
+        ConfigureMeta(builder);
+        ConfigureLifecycle(builder);
+        ConfigureDesign(builder);
+
+        builder.HasIndex(e => e.Meta.Code.Value)
+            .HasDatabaseName("ix_forms_code_unique")
+            .IsUnique();
+    }
+
+    private static void ConfigureMeta(EntityTypeBuilder<EvaluationForm> builder)
+    {
+        builder.ComplexProperty(x => x.Meta, meta =>
+        {
+            meta.ComplexProperty(m => m.Name)
+                .Property(p => p.Value)
+                .HasColumnName("name")
+                .HasColumnType("text")
+                .IsRequired();
+
+            meta.Property(m => m.Description)
+                .HasColumnName("description")
+                .HasColumnType("text");
+
+            meta.Property(m => m.Tags)
+                .HasColumnName("tags")
+                .HasColumnType("jsonb")
+                .IsRequired();
+
+            meta.ComplexProperty(m => m.Code)
+                .Property(p => p.Value)
+                .HasColumnName("code")
+                .HasColumnType("text")
+                .IsRequired();
+        });
+    }
+
+    private static void ConfigureLifecycle(EntityTypeBuilder<EvaluationForm> builder)
+    {
+        builder.ComplexProperty(x => x.Lifecycle, lc =>
+        {
+            lc.Property(l => l.Status)
+                .HasColumnName("status")
+                .HasConversion<string>()
+                .HasMaxLength(16)
+                .IsRequired();
+
+            lc.ComplexProperty(l => l.Validity, v =>
+            {
+                v.Property(p => p.Start).HasColumnName("valid_from");
+                v.Property(p => p.End).HasColumnName("valid_to");
+            });
+
+            lc.ComplexProperty(l => l.Audit, audit =>
+            {
+                audit.ComplexProperty(a => a.Created, s =>
+                {
+                    s.Property(p => p.UserId).HasColumnName("created_by").HasMaxLength(100).IsRequired();
+                    s.Property(p => p.At).HasColumnName("created_at").IsRequired();
+                });
+                audit.ComplexProperty(a => a.Updated, s =>
+                {
+                    s.Property(p => p.UserId).HasColumnName("updated_by").HasMaxLength(100);
+                    s.Property(p => p.At).HasColumnName("updated_at");
+                });
+                audit.ComplexProperty(a => a.StateChanged, s =>
+                {
+                    s.Property(p => p.UserId).HasColumnName("state_changed_by").HasMaxLength(100);
+                    s.Property(p => p.At).HasColumnName("state_changed_at");
+                });
+            });
+        });
+    }
+
+    private static void ConfigureDesign(EntityTypeBuilder<EvaluationForm> builder)
+    {
+        builder.OwnsOne(x => x.Design, design =>
+        {
+            design.Property(d => d.Calculation)
+                .HasColumnName("calculation")
+                .HasConversion<string>()
+                .HasMaxLength(32)
+                .IsRequired();
+
+            design.HasMany(d => d.Groups)
+                .WithOne()
+                .HasForeignKey("form_id")
+                .OnDelete(DeleteBehavior.Cascade);
+
+            design.HasMany(d => d.Criteria)
+                .WithOne()
+                .HasForeignKey("form_id")
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+}
+

--- a/src/Infrastructure/Configurations/FormCriterionConfiguration.cs
+++ b/src/Infrastructure/Configurations/FormCriterionConfiguration.cs
@@ -1,0 +1,69 @@
+using CascVel.Module.Evaluations.Management.Domain.Entities.Forms;
+using CascVel.Module.Evaluations.Management.Domain.Entities.Criteria;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CascVel.Module.Evaluations.Management.Infrastructure.Configurations;
+
+internal sealed class FormCriterionConfiguration : IEntityTypeConfiguration<FormCriterion>
+{
+    public void Configure(EntityTypeBuilder<FormCriterion> builder)
+    {
+        builder.ToTable("form_criteria");
+        builder.Property<long>("id").ValueGeneratedOnAdd();
+        builder.HasKey("id");
+
+        builder.Property<long?>("form_id").HasColumnName("form_id");
+        builder.Property<long?>("group_id").HasColumnName("group_id");
+
+        builder.HasOne<EvaluationForm>()
+            .WithMany()
+            .HasForeignKey("form_id")
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne<FormGroup>()
+            .WithMany(g => g.Criteria)
+            .HasForeignKey("group_id")
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Property<long>("criterion_id");
+        builder.HasOne(c => c.Criterion)
+            .WithMany()
+            .HasForeignKey("criterion_id")
+            .OnDelete(DeleteBehavior.Cascade);
+        builder.Property<long>("criterion_id").HasColumnName("criterion_id");
+
+        builder.ComplexProperty(c => c.Order, order =>
+        {
+            order.Property(o => o.Value).HasColumnName("order_index").IsRequired();
+        });
+
+        builder.ComplexProperty(c => c.Weight, weight =>
+        {
+            weight.Property(w => w.Percent).HasColumnName("weight");
+        });
+
+        builder.HasCheckConstraint("ck_form_criteria_owner", "((form_id IS NULL) <> (group_id IS NULL))");
+
+        builder.HasIndex("form_id", "Order_Value")
+            .HasDatabaseName("ix_form_criteria_root_order_unique")
+            .IsUnique()
+            .HasFilter("group_id IS NULL");
+
+        builder.HasIndex("group_id", "Order_Value")
+            .HasDatabaseName("ix_form_criteria_group_order_unique")
+            .IsUnique()
+            .HasFilter("group_id IS NOT NULL");
+
+        builder.HasIndex("form_id", "criterion_id")
+            .HasDatabaseName("ix_form_criteria_root_unique")
+            .IsUnique()
+            .HasFilter("group_id IS NULL");
+
+        builder.HasIndex("group_id", "criterion_id")
+            .HasDatabaseName("ix_form_criteria_group_unique")
+            .IsUnique()
+            .HasFilter("group_id IS NOT NULL");
+    }
+}
+

--- a/src/Infrastructure/Configurations/FormGroupConfiguration.cs
+++ b/src/Infrastructure/Configurations/FormGroupConfiguration.cs
@@ -1,0 +1,61 @@
+using CascVel.Module.Evaluations.Management.Domain.Entities.Forms;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CascVel.Module.Evaluations.Management.Infrastructure.Configurations;
+
+internal sealed class FormGroupConfiguration : IEntityTypeConfiguration<FormGroup>
+{
+    public void Configure(EntityTypeBuilder<FormGroup> builder)
+    {
+        builder.ToTable("form_groups");
+        builder.HasKey(g => g.Id);
+        builder.Property(g => g.Id).HasColumnName("id").ValueGeneratedOnAdd();
+
+        builder.Property(g => g.Title)
+            .HasColumnName("title")
+            .HasColumnType("text")
+            .IsRequired();
+
+        builder.ComplexProperty(g => g.Order, order =>
+        {
+            order.Property(o => o.Value).HasColumnName("order_index").IsRequired();
+        });
+
+        builder.ComplexProperty(g => g.Weight, weight =>
+        {
+            weight.Property(w => w.Percent).HasColumnName("weight");
+        });
+
+        builder.Property<long?>("form_id").HasColumnName("form_id");
+        builder.Property<long?>("parent_group_id").HasColumnName("parent_group_id");
+
+        builder.HasOne<EvaluationForm>()
+            .WithMany()
+            .HasForeignKey("form_id")
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne<FormGroup>()
+            .WithMany(g => g.Groups)
+            .HasForeignKey("parent_group_id")
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasMany(g => g.Criteria)
+            .WithOne()
+            .HasForeignKey("group_id")
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasCheckConstraint("ck_form_groups_owner", "((form_id IS NULL) <> (parent_group_id IS NULL))");
+
+        builder.HasIndex("form_id", "Order_Value")
+            .HasDatabaseName("ix_form_groups_root_order_unique")
+            .IsUnique()
+            .HasFilter("parent_group_id IS NULL");
+
+        builder.HasIndex("parent_group_id", "Order_Value")
+            .HasDatabaseName("ix_form_groups_nested_order_unique")
+            .IsUnique()
+            .HasFilter("parent_group_id IS NOT NULL");
+    }
+}
+


### PR DESCRIPTION
## Summary
- configure EvaluationForm with meta, lifecycle and design settings
- map form groups with self-referencing hierarchy and criteria storage
- map criteria placement to prevent duplicates and ensure ordering

## Testing
- `dotnet build -q` *(fails: command not found)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: CONNECT tunnel 403)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0322a4ffc832884f0700cea686078